### PR TITLE
fix: ensure Navbar correctly detects current route on initial load

### DIFF
--- a/src/app/core/components/navbar/navbar.component.ts
+++ b/src/app/core/components/navbar/navbar.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
-import { filter } from 'rxjs';
+import { filter, startWith } from 'rxjs';
 
 @Component({
   selector: 'app-navbar',
@@ -23,9 +23,12 @@ export class NavbarComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        startWith(this.route)
+      )
       .subscribe((event) => {
-        this.currentRoute = event.urlAfterRedirects;
+        this.currentRoute = event.url;
       });
   }
 }


### PR DESCRIPTION
This pull request fixes an issue where the NavbarComponent failed to detect the current route when the application was directly accessed via a deep link (e.g., /blogs, /auth/login). The issue occurred because the Angular NavigationEnd event wasn't captured on initial page load, as the event was already emitted before the component subscribed to router.events.
